### PR TITLE
Match strictly to the existing rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,8 @@
 
 module.exports = {
   env: {
-    browser: true,
     es6: true,
-    node: true
+    browser: true
   },
   parserOptions: {
     ecmaVersion: 6,
@@ -12,19 +11,19 @@ module.exports = {
   },
   extends: "eslint:recommended",
   rules: {
-    "camelcase": "warn",
-    "eol-last": "warn",
+    "camelcase": ["warn"],
+    "eol-last": ["warn"],
     "eqeqeq": ["error", "smart"],
-    "indent": ["warn", 2],
+    "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
-    "no-console": "warn",
-    "no-debugger": "warn",
-    "no-spaced-func": "warn",
+    "no-console": ["warn"],
+    "no-debugger": ["warn"],
+    "no-spaced-func": ["warn"],
     "no-unused-vars": ["warn", { "args": "none" }],
-    "no-var": "error",
-    "quotes": ["warn", "double", {"avoidEscape": true, "allowTemplateLiterals": true}],
+    "no-var": ["error"],
+    "quotes": ["warn", "double", {"avoidEscape": true}],
     "semi": ["error", "never"],
     "space-before-function-paren": ["warn", "never"],
-    "strict": "error"
+    "strict": ["error"]
   }
 }


### PR DESCRIPTION
`$(npm bin)/eslint --print-config` の出力に extends 以外の差異がでないところまで調整しました。

``` diff
--- /tmp/old    2016-07-26 03:05:41.000000000 +0900
+++ /tmp/new    2016-07-26 03:28:47.000000000 +0900
@@ -948,5 +948,5 @@
     "sourceType": "script"
   },
   "ecmaFeatures": {},
-  "extends": "eslint:recommended"
+  "extends": "@codetakt"
 }
```
