### PR TITLE
Prohibit the space-before-function-paren

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -13,3 +13,6 @@ rules:
   no-irregular-whitespace:
     - error
     - skipRegExps: true
+  space-before-function-paren:
+    - error
+    - never


### PR DESCRIPTION
Simular the `SpaceAfterMethodName` of RuboCop rule.