### PR TITLE
We accept JavaScript standards and provide them almost verbatim

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,14 +1,6 @@
 ---
 extends: standard
 
-env:
-  browser: true
-  es6: true
-  jquery: true
-
-parserOptions:
-  sourceType: script
-
 rules:
   linebreak-style:
     - error


### PR DESCRIPTION
So remove our extra overrides.