### PR TITLE
Allow particular window globals

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,20 @@
 ---
 extends: standard
 
+env:
+  commonjs: false
+  node: false
+
+globals:
+  # window globals
+  URL: false
+  clearInterval: false
+  clearTimeout: false
+  console: false
+  location: false
+  setInterval: false
+  setTimeout: false
+
 rules:
   linebreak-style:
     - error


### PR DESCRIPTION
Currently we're using `env: browser: true` to allow to use window globals like `setTimeout()` for every repo which adopts this rule.
But it also contains harmful ones like `event` or `left`.
So this PR adds limited set of globals in addition of eslint-config-standard allows (window, document, navigator).
Then we can disable env: browser..!

Also, this disables envs come from standard (so `strict` rule correctly detects type of script).