### PR TITLE
Leave the Prettier the printWidth setting to a product team

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -23,8 +23,7 @@ globals:
 rules:
   prettier/prettier:
     - warn
-    - printWidth: 120
-      semi: false
+    - semi: false
       singleQuote: true
 
   no-case-declarations:


### PR DESCRIPTION
That option is too strong. Prettier fills in the lines that don't meet
it and then wrap back.

In my humble opinion, that default value and their recommendations for
it are reasonable.

> For readability we recommend against using more than 80 characters:
>
> In code styleguides, maximum line length rules are often set to 100
> or 120. However, when humans write code, they don't strive to reach
> the maximum number of columns on every line. Developers often use
> whitespace to break up long lines for readability. In practice, the
> average line length often ends up well below the maximum.
>
> Prettier, on the other hand, strives to fit the most code into every
> line. With the print width set to 120, prettier may produce overly
> compact, or otherwise undesirable code.

<https://prettier.io/docs/en/options.html#print-width>