### PR TITLE
add vue/component-tags-order error rule

### DIFF
--- a/config/vue.yml
+++ b/config/vue.yml
@@ -16,3 +16,4 @@ rules:
     - error
     - html:
         void: always
+  vue/component-tags-order: error


### PR DESCRIPTION
以下のRuleが`plugin:vue/recommended`にするだけでは適用されていなかったので、Ruleに追加しました
バージョンをあげれば良いかもしれませんが、一旦これで.
https://eslint.vuejs.org/rules/component-tags-order.html