### PR TITLE
componentの順番をtemplate -> script -> styleの順に固定にする

### DIFF
--- a/config/vue.yml
+++ b/config/vue.yml
@@ -16,4 +16,9 @@ rules:
     - error
     - html:
         void: always
-  vue/component-tags-order: error
+  vue/component-tags-order:
+    - error
+    - order:
+        - template
+        - script
+        - style


### PR DESCRIPTION
何もorderを指定しないとscript -> template -> styleの順であったため、修正
(公式ドキュメントではscriptとtemplateは順不動)