### PR TITLE
componentの順番をtemplate -> script -> styleの順でない場合、warningを出す

### DIFF
--- a/config/vue.yml
+++ b/config/vue.yml
@@ -17,7 +17,7 @@ rules:
     - html:
         void: always
   vue/component-tags-order:
-    - error
+    - warn
     - order:
         - template
         - script


### PR DESCRIPTION
errorだと、scriptがない場合に対応できないため